### PR TITLE
workbench-ext: add some metadata fields

### DIFF
--- a/projects/workbench/init/public/workbench-ext/package.json
+++ b/projects/workbench/init/public/workbench-ext/package.json
@@ -4,6 +4,12 @@
 	"name": "squigil",
 	"version": "1.0.0",
 	"publisher": "wh0",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/wh0/squigil.git",
+		"directory": "projects/workbench/init/public/workbench-ext"
+	},
 	"main": "./browser.js",
 	"browser": "./browser.js",
 	"activationEvents": [


### PR DESCRIPTION
https://marketplace.visualstudio.com/items?itemName=wh0.squigil the published extension has like no links. supposedly setting a github repo fills in a lot of them. this is a directory in a larger repo so I think we gotta set the directory

oh and the license on the whole repo is MIT, so setting that too