### PR TITLE
workbench-ext: ignore fs misbehavior sign in requests

### DIFF
--- a/projects/workbench/init/public/workbench-ext/browser.js
+++ b/projects/workbench/init/public/workbench-ext/browser.js
@@ -227,7 +227,15 @@ function authenticationSessionFromAdminSecret(/** @type {string} */ alias, /** @
 exports.activate = (/** @type {vscode.ExtensionContext} */ context) => {
 	console.log('squigil enter activate'); // %%%
 
+	const sqUnwantedAliases = {
+		'node_modules': true,
+		'package.json': true,
+	};
+
 	async function sqGetAdminSettings(/** @type {string} */ alias) {
+		if (Object.hasOwn(sqUnwantedAliases, alias)) {
+			throw new Error(`Alias ${alias} unwanted`);
+		}
 		let adminBase;
 		const /** @type {{[alias: string]: string}} */ adminBaseOverrides = vscode.workspace.getConfiguration('squigil').get('adminBaseOverrides', {});
 		if (Object.hasOwn(adminBaseOverrides, alias)) {


### PR DESCRIPTION
we keep getting requests for sign in for e.g. `https://package.json` and `https://node_modules`. I tracked this down to some features searching "up" from your project files from

```
squigil://squigil.edgecompute.app/whatev/ayo.js
squigil://squigil.edgecompute.app/whatev/node_modules
squigil://squigil.edgecompute.app/node_modules
squigil://node_modules
```

i.e. some logic out there doesn't take into account that part of it is authority, not path.

anyway, this pr rejects the request so that we don't go on and bug our auth provider and thus put that annoying sign in "1" in the corner