### PR TITLE
workbench-ext: ignore packaged vsix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
 /bin
 /pkg
+
+/projects/workbench/init/public/workbench-ext/*.vsix


### PR DESCRIPTION
the vscode extension build just dumps it out into the extension directory. let's not fight that. here's a .gitignore entry so I can get back to indiscriminate git add-ing