### PR TITLE
workbench-ext: add preview command

### DIFF
--- a/projects/workbench/init/public/workbench-ext/browser.js
+++ b/projects/workbench/init/public/workbench-ext/browser.js
@@ -482,6 +482,26 @@ exports.activate = (/** @type {vscode.ExtensionContext} */ context) => {
 		vscode.workspace.updateWorkspaceFolders(end, 0, {uri: vscode.Uri.from({scheme: 'squigil', authority: session.account.id, path: '/'})});
 	}));
 
+	context.subscriptions.push(vscode.commands.registerCommand('wh0.squigil.preview', async (/** @type {vscode.Uri} */ uri) => {
+		console.log('squigil command preview', uri.toString()); // %%%
+		let path = uri.path;
+		if (path.startsWith('/public/')) {
+			path = path.replace(/^\/public\//, '/');
+			if (path.endsWith('/index.html')) {
+				path = path.replace(/\/index\.html/, '/');
+			}
+		} else if (path.endsWith('/index.js')) {
+			path = path.replace(/\/index\.js$/, '/~/');
+		}
+		const previewUri = vscode.Uri.from({
+			scheme: 'https',
+			authority: uri.authority,
+			path,
+		});
+		const ok = await vscode.env.openExternal(previewUri);
+		if (!ok) throw new Error(`Environment didn't open preview URI ${previewUri}`);
+	}));
+
 	context.subscriptions.push(vscode.commands.registerCommand('wh0.squigil.asdf', async () => {
 		console.log('squigil command asdf'); // %%%
 		for (const alias in sqTrees) {

--- a/projects/workbench/init/public/workbench-ext/package.json
+++ b/projects/workbench/init/public/workbench-ext/package.json
@@ -24,6 +24,7 @@
 		],
 		"commands": [
 			{"command": "wh0.squigil.open_installation", "title": "Drop by Squigil's House"},
+			{"command": "wh0.squigil.preview", "title": "Preview", "icon": "$(link-external)"},
 			{"command": "wh0.squigil.asdf", "title": "Mash Buttons on Squigil's Home Phone"}
 		],
 		"configuration": {
@@ -39,6 +40,27 @@
 			"squigil.adminBaseOverrides": {
 				"127.0.0.1:7676": "http://127.0.0.1:7676/admin/~"
 			}
+		},
+		"menus": {
+			"commandPalette": [
+				{
+					"command": "wh0.squigil.preview",
+					"when": "false"
+				}
+			],
+			"editor/title": [
+				{
+					"command": "wh0.squigil.preview",
+					"group": "navigation",
+					"when": "resourceScheme == squigil && resourcePath =~ /^\\/public\\/|\\/index.js$/"
+				}
+			],
+			"explorer/context": [
+				{
+					"command": "wh0.squigil.preview",
+					"when": "resourceScheme == squigil && resourcePath =~ /^\\/public\\/|\\/index.js$/"
+				}
+			]
 		}
 	},
 	"engines": {


### PR DESCRIPTION
look out for this new feature on supported files

<img width="322" height="401" alt="image" src="https://github.com/user-attachments/assets/09e1e36d-f5fb-4a92-9928-7e67aee93d2e" />

<img width="241" height="66" alt="image" src="https://github.com/user-attachments/assets/182304e6-8bfc-41e6-b6bf-348c72b9235d" />

support for

- static files for the root entrance in /public
- index.html files in the root entrance
- index.js entrance files