### PR TITLE
workbench-ext: add preview base overrides, fix local preview

### DIFF
--- a/projects/workbench/init/public/workbench-ext/package.json
+++ b/projects/workbench/init/public/workbench-ext/package.json
@@ -33,12 +33,19 @@
 				"squigil.adminBaseOverrides": {
 					"type": "object",
 					"additionalProperties": {"type": "string"}
+				},
+				"squigil.previewBaseOverrides": {
+					"type": "object",
+					"additionalProperties": {"type": "string"}
 				}
 			}
 		},
 		"configurationDefaults": {
 			"squigil.adminBaseOverrides": {
 				"127.0.0.1:7676": "http://127.0.0.1:7676/admin/~"
+			},
+			"squigil.previewBaseOverrides": {
+				"127.0.0.1:7676": "http://127.0.0.1:7676"
 			}
 		},
 		"menus": {


### PR DESCRIPTION
the preview always went to `https://` installation alias, which doesn't work for local http-only servers. this adds a new previewBaseOverrides config

<img width="470" height="153" alt="image" src="https://github.com/user-attachments/assets/b9c15de2-3c79-45d9-ab31-4fd0cb5c7be9" />

oh and in case I forget later: we set the default in a configurationDefaults instead of in the configuration...default because this way configurationDefaults from the workbench file merges with our default instead of replacing it