### PR TITLE
workbench-ext: keep value when picking other

### DIFF
--- a/projects/workbench/init/public/workbench-ext/browser.js
+++ b/projects/workbench/init/public/workbench-ext/browser.js
@@ -433,16 +433,30 @@ exports.activate = (/** @type {vscode.ExtensionContext} */ context) => {
 				}
 				items.push(otherItem);
 			}
-			const aliasPicked = await vscode.window.showQuickPick(items, {
-				title: 'Sign In to Squigil\'s House',
-				placeHolder: 'Installation Alias',
-				ignoreFocusOut: true,
+			const aliasQuickPick = vscode.window.createQuickPick();
+			const /** @type {Promise<vscode.QuickPickItem | null>} */ aliasPickedPromised = new Promise((resolve, reject) => {
+				aliasQuickPick.onDidHide(() => {
+					resolve(null);
+				});
+				aliasQuickPick.onDidAccept(() => {
+					resolve(aliasQuickPick.selectedItems[0]);
+				});
 			});
+			aliasQuickPick.items = items;
+			aliasQuickPick.title = 'Sign In to Squigil\'s House';
+			aliasQuickPick.placeholder = 'Installation Alias';
+			aliasQuickPick.ignoreFocusOut = true;
+			aliasQuickPick.show();
+			const aliasPicked = await aliasPickedPromised;
+			const aliasPickedValue = aliasQuickPick.value;
+			aliasQuickPick.dispose();
 			if (!aliasPicked) throw new Error('Cancelled');
 			let alias;
 			if (aliasPicked === otherItem) {
 				const aliasPrompted = await vscode.window.showInputBox({
 					title: 'Sign In to Squigil\'s House',
+					value: aliasPickedValue,
+					valueSelection: [aliasPickedValue.length, aliasPickedValue.length],
 					prompt: 'e.g. squigil.edgecompute.app or 127.0.0.1:7676',
 					placeHolder: 'Installation Alias',
 					ignoreFocusOut: true,


### PR DESCRIPTION
I keep typing the hostname in the quick pick and then getting annoyed that I have to type it again in the input box. this PR makes it keep the value so you can select "Other..." and then just press enter again.

have to switch from showQuickPick to createQuickPick to do this.

when creating the input box, we put the cursor at the end, which is where I imagine the cursor normally is after you type text in the quick pick. the quick pick doesn't reveal the true cursor/selection index, unfortunately.

<img width="610" height="102" alt="image" src="https://github.com/user-attachments/assets/21fe9e54-132d-4049-9371-b0692fa6526e" />

press enter :point_down: 

<img width="610" height="102" alt="image" src="https://github.com/user-attachments/assets/bae56144-9fe5-48f0-8100-05490c915aeb" />


oh and unrelated annoyance: the authentication system has its own account picker that comes before this, that we don't do anything about :angry: 