### PR TITLE
package: add fastlyHTMLRewriter builtin module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import * as fastlyEnv from 'fastly:env';
 import * as fastlyExperimental from 'fastly:experimental';
 import * as fastlyFanout from 'fastly:fanout';
 import * as fastlyGeolocation from 'fastly:geolocation';
+import * as fastlyHTMLRewriter from 'fastly:html-rewriter';
 import * as fastlyKVStore from 'fastly:kv-store';
 import * as fastlyLogger from 'fastly:logger';
 import * as fastlySecretStore from 'fastly:secret-store';
@@ -32,6 +33,7 @@ const builtinModules = {
 	fastlyExperimental,
 	fastlyFanout,
 	fastlyGeolocation,
+	fastlyHTMLRewriter,
 	fastlyKVStore,
 	fastlyLogger,
 	fastlySecretStore,


### PR DESCRIPTION
fixes #11 

only this html rewriter is added. turns out the last version was built with 3.34.0 according to the package-lock.json, which is why the websocket module was already there

a curiosity: the types also has a fastly:body module. not including that for now, as it doesn't show up in the docs https://js-compute-reference-docs.edgecompute.app/docs/