### PR TITLE
docs, workbench-ext: unify placeholders

### DIFF
--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -15,7 +15,7 @@
    +	ay
    +</p>
    ```
-1. Open that file on your site without the `public/` part, e.g. at `https://???.edgecompute.app/note.html`.
+1. Open that file on your site without the `public/` part, e.g. at `https://<SUBDOMAIN>.edgecompute.app/note.html` for your subdomain _SUBDOMAIN_.
 
 ## Adding resources
 
@@ -46,7 +46,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
    +<link rel="stylesheet" href="note.css">
    ```
-1. Check the page, e.g. at `https://???.edgecompute.app/note.html`, and it should be using the external stylesheet.
+1. Check the page, e.g. at `https://<SUBDOMAIN>.edgecompute.app/note.html`, and it should be using the external stylesheet.
 
 ## Making a dynamic page
 
@@ -79,19 +79,19 @@
    }
    ```
    See the code [src/index.js:65](../src/index.js#L65) in case this gets out of date.
-1. Now you should be able to go to e.g. `https://???.edgecompute.app/info/~/` and see some JSON.
+1. Now you should be able to go to e.g. `https://<SUBDOMAIN>.edgecompute.app/info/~/` and see some JSON.
 
 ## Running some code as the admin
 
 1. You make a POST request to `/admin/~/eval` like this:
    ```sh
-   SQUIGIL_ADMIN_SECRET=your_admin_secret \
+   SQUIGIL_ADMIN_SECRET='<ADMIN_SECRET>' \
    curl \
    	--variable %SQUIGIL_ADMIN_SECRET \
    	--variable 'body=return new Response('"'"'hi\n'"'"');' \
    	-X POST \
    	--expand-header 'Authorization: Bearer {{SQUIGIL_ADMIN_SECRET}}' \
-   	--expand-url 'https://???.edgecompute.app/admin/~/eval?body={{body:url}}'
+   	--expand-url 'https://<SUBDOMAIN>.edgecompute.app/admin/~/eval?body={{body:url}}'
    ```
    That, similar to the dynamic page, runs some code as the body of an async function with some arguments given, and it should return a `Response`.
    Currently the arguments are:

--- a/docs/gradual-start.md
+++ b/docs/gradual-start.md
@@ -6,7 +6,7 @@
 4. Save the secret somewhere.
 5. Copy the `'...': true,` line, add it to [`init/admin/index.js`](../init/admin/index.js) in the `allowedSecretDigests` dictionary.
 6. Run `npm run deploy` and follow interactive instructions. It'll ask you about several files to use in the KV store, but they should already be set, so just press enter on those.
-7. When it's deployed, it'll be at a domain. If you didn't set up a custom domain, it'll be `(something).edgecompute.app`. Remember this or save it.
+7. When it's deployed, it'll be at a domain. If you didn't set up a custom domain, it'll be `<SUBDOMAIN>.edgecompute.app` for some subdomain _SUBDOMAIN_. Remember this or save it.
 8. Go to https://vscode.dev/ or get Visual Studio Code or a compatible editor.
 9. Install this extension https://marketplace.visualstudio.com/items?itemName=wh0.squigil.
 10. Press F1 or Ctrl+Shift+P or similar and use "Drop by Squigil's House."

--- a/docs/manage-start.md
+++ b/docs/manage-start.md
@@ -6,11 +6,11 @@ See [Gradual start](gradual-start.md) for how to do it with the CLI if you don't
 (Steps are current as of 2025/10/29.)
 
 1. Go to the "Create a Compute service" page https://manage.fastly.com/compute/new, click "Create an empty service."
-1. (In your new whatever.edgecompute.app compute service, in "Service configuration," in "Domains") copy the automatically generated whatever.edgecompute.app domain, paste it in the "Domain name of your website..." box, click "Add."
+1. (In your new _SUBDOMAIN_.edgecompute.app compute service with some subdomain _SUBDOMAIN_, in "Service configuration," in "Domains") copy the automatically generated _SUBDOMAIN_.edgecompute.app domain, paste it in the "Domain name of your website..." box, click "Add."
 1. Click "KV stores" and click "Create KV store in Resources" and click "Create store," type `stuff`, click "Create."
 1. Click "Add item," in "Key" type `admin/index.js`, click "Upload file," select your prepared admin/index.js file ([source](../init/admin/index.js), [preparation tool](https://squigil.edgecompute.app/admin-setup.html)), click "Save."
-1. Click "Linked Services," "Link service," check your whatever.edgecompute.app (only click the checkbox, don't click the name, which is a link to the service page), click "Next," click "Link only."
-1. Go back to your whatever.edgecompute.app compute service, click "Service configuration," click "Package," click "BROWSE FOR PACKAGE," select the prebuilt squigil.tar.gz file ([releases](https://github.com/wh0/squigil/releases)).
+1. Click "Linked Services," "Link service," check your _SUBDOMAIN_.edgecompute.app (only click the checkbox, don't click the name, which is a link to the service page), click "Next," click "Link only."
+1. Go back to your _SUBDOMAIN_.edgecompute.app compute service, click "Service configuration," click "Package," click "BROWSE FOR PACKAGE," select the prebuilt squigil.tar.gz file ([releases](https://github.com/wh0/squigil/releases)).
 1. Click "Activate."
 
 Then you'll have only the admin entrance script set up, which is just enough to set up editor and paste in the rest of the stuff.

--- a/docs/update-speed.md
+++ b/docs/update-speed.md
@@ -63,8 +63,8 @@ cd ..
 awk '$1 == "real" { print $2; }' fastly-cli-output.txt
 
 cd squigil
-SQUIGIL_DOMAIN=squigil.edgecompute.app \
-SQUIGIL_ADMIN_SECRET=your_admin_secret \
+SQUIGIL_DOMAIN='<SUBDOMAIN>.edgecompute.app' \
+SQUIGIL_ADMIN_SECRET='<ADMIN_SECRET>' \
 ./time.sh 2>&1 | tee ../squigil-output.txt
 cd ..
 awk '$1 == "real" { print $2; }' squigil-output.txt

--- a/projects/workbench/init/public/workbench-ext/browser.js
+++ b/projects/workbench/init/public/workbench-ext/browser.js
@@ -457,7 +457,7 @@ exports.activate = (/** @type {vscode.ExtensionContext} */ context) => {
 					title: 'Sign In to Squigil\'s House',
 					value: aliasPickedValue,
 					valueSelection: [aliasPickedValue.length, aliasPickedValue.length],
-					prompt: 'e.g. squigil.edgecompute.app or 127.0.0.1:7676',
+					prompt: 'e.g. <SUBDOMAIN>.edgecompute.app or 127.0.0.1:7676',
 					placeHolder: 'Installation Alias',
 					ignoreFocusOut: true,
 				});


### PR DESCRIPTION
fixes #29 

rules:

1. in docs where formatting is supported, use italics
2. in docs, acknowledge the existence of a placeholder at least when it first shows up
3. in code and in docs where formatting is not supported, use angle brackets. beware places like shell and html where angle brackets are used in the syntax :grimacing: 
4. use all caps with underscores

gonna leave the admin secret digest as it is though